### PR TITLE
Don't tell nginx to use zstd compression when Accept-Encoding only contains gzip

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -215,12 +215,7 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
 
     r->gzip_vary = 1;
 
-    if (!r->gzip_tested) {
-        if (ngx_http_zstd_ok(r) != NGX_OK) {
-            return ngx_http_next_header_filter(r);
-        }
-
-    } else if (!r->gzip_ok) {
+    if (ngx_http_zstd_ok(r) != NGX_OK) {
         return ngx_http_next_header_filter(r);
     }
 


### PR DESCRIPTION


I enabled zstd encoding for many mime-types in my nginx config and noticed that firefox received zstd encoded content despite not sending zstd in the Accept-encoding header.