### PR TITLE
fix: avoid using deprecated ZSTD_initCStream_usingCDict if zstd version >= 1.5.0

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -603,7 +603,25 @@ ngx_http_zstd_filter_create_cstream(ngx_http_request_t *r,
     /* TODO use the advanced initialize functions */
 
     if (zlcf->dict) {
+#if ZSTD_VERSION_NUMBER >= 10500
+        rc = ZSTD_CCtx_reset(cstream, ZSTD_reset_session_only);
+        if (ZSTD_isError(rc)) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "ZSTD_CCtx_reset() failed: %s",
+                          ZSTD_getErrorName(rc));
+            goto failed;
+        }
+
+        rc = ZSTD_CCtx_refCDict(cstream, zlcf->dict);
+        if (ZSTD_isError(rc)) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "ZSTD_CCtx_refCDict() failed: %s",
+                          ZSTD_getErrorName(rc));
+            goto failed;
+        }
+#else
         rc = ZSTD_initCStream_usingCDict(cstream, zlcf->dict);
+#endif
         if (ZSTD_isError(rc)) {
             ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
                           "ZSTD_initCStream_usingCDict() failed: %s",


### PR DESCRIPTION
The function `ZSTD_initCStream_usingCDict` was deprecated since zstd `1.5.0`. In such a case, let's use `ZSTD_CCtx_reset` and `ZSTD_CCtx_refCDict` instead.

This PR fixed the issue https://github.com/tokers/zstd-nginx-module/pull/28.