### PR TITLE
Refactor encoding check as per brotli module

### DIFF
--- a/common/ngx_http_zstd_common.c
+++ b/common/ngx_http_zstd_common.c
@@ -1,0 +1,64 @@
+#include "ngx_http_zstd_common.h"
+
+static /* const */ char kEncoding[] = "zstd";
+static const size_t kEncodingLen = 4;
+
+static ngx_int_t check_accept_encoding(ngx_http_request_t* req) {
+  ngx_table_elt_t* accept_encoding_entry;
+  ngx_str_t* accept_encoding;
+  u_char* cursor;
+  u_char* end;
+  u_char before;
+  u_char after;
+
+  accept_encoding_entry = req->headers_in.accept_encoding;
+  if (accept_encoding_entry == NULL) return NGX_DECLINED;
+  accept_encoding = &accept_encoding_entry->value;
+
+  if (accept_encoding->len < kEncodingLen) return NGX_DECLINED;
+
+  cursor = accept_encoding->data;
+  end = cursor + accept_encoding->len;
+  while (1) {
+    u_char digit;
+    /* It would be an idiotic idea to rely on compiler to produce performant
+       binary, that is why we just do -1 at every call site. */
+    cursor = ngx_strcasestrn(cursor, kEncoding, kEncodingLen - 1);
+    if (cursor == NULL) return NGX_DECLINED;
+    before = (cursor == accept_encoding->data) ? ' ' : cursor[-1];
+    cursor += kEncodingLen;
+    after = (cursor >= end) ? ' ' : *cursor;
+    if (before != ',' && before != ' ') continue;
+    if (after != ',' && after != ' ' && after != ';') continue;
+
+    /* Check for ";q=0[.[0[0[0]]]]" */
+    while (*cursor == ' ') cursor++;
+    if (*(cursor++) != ';') break;
+    while (*cursor == ' ') cursor++;
+    if (*(cursor++) != 'q') break;
+    while (*cursor == ' ') cursor++;
+    if (*(cursor++) != '=') break;
+    while (*cursor == ' ') cursor++;
+    if (*(cursor++) != '0') break;
+    if (*(cursor++) != '.') return NGX_DECLINED; /* ;q=0, */
+    digit = *(cursor++);
+    if (digit < '0' || digit > '9') return NGX_DECLINED; /* ;q=0., */
+    if (digit > '0') break;
+    digit = *(cursor++);
+    if (digit < '0' || digit > '9') return NGX_DECLINED; /* ;q=0.0, */
+    if (digit > '0') break;
+    digit = *(cursor++);
+    if (digit < '0' || digit > '9') return NGX_DECLINED; /* ;q=0.00, */
+    if (digit > '0') break;
+    return NGX_DECLINED; /* ;q=0.000 */
+  }
+  return NGX_OK;
+}
+
+ngx_int_t ngx_http_zstd_check_request(ngx_http_request_t* req) {
+  if (req != req->main) return NGX_DECLINED;
+  if (check_accept_encoding(req) != NGX_OK) return NGX_DECLINED;
+  req->gzip_tested = 1;
+  req->gzip_ok = 0;
+  return NGX_OK;
+}

--- a/common/ngx_http_zstd_common.h
+++ b/common/ngx_http_zstd_common.h
@@ -1,0 +1,8 @@
+#ifndef _NGX_HTTP_ZSTD_COMMON_INCLUDED_
+#define _NGX_HTTP_ZSTD_COMMON_INCLUDED_
+
+#include <ngx_http.h>
+
+ngx_int_t ngx_http_zstd_check_request(ngx_http_request_t* req);
+
+#endif /* _NGX_HTTP_ZSTD_COMMON_INCLUDED_ */

--- a/filter/config
+++ b/filter/config
@@ -98,7 +98,7 @@ fi
 
 NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
 
-HTTP_ZSTD_SRCS="$ngx_addon_dir/filter/ngx_http_zstd_filter_module.c"
+HTTP_ZSTD_SRCS="$ngx_addon_dir/common/ngx_http_zstd_common.c $ngx_addon_dir/filter/ngx_http_zstd_filter_module.c"
 
 ngx_addon_name=ngx_http_zstd_filter_module
 ngx_module_type=HTTP_FILTER

--- a/static/config
+++ b/static/config
@@ -100,7 +100,7 @@ CFLAGS="$ngx_zstd_opt_I $CFLAGS"
 NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
 
 # build the ngx_http_zstd_static_module
-HTTP_ZSTD_SRCS="$ngx_addon_dir/static/ngx_http_zstd_static_module.c"
+HTTP_ZSTD_SRCS="$ngx_addon_dir/common/ngx_http_zstd_common.c $ngx_addon_dir/static/ngx_http_zstd_static_module.c"
 
 ngx_addon_name=ngx_http_zstd_static_module
 ngx_module_type=HTTP


### PR DESCRIPTION
Using zstd-nginx-module with the following configuration, does not work on for example `autoindex` generated documents.

```
        zstd			on;
        zstd_min_length		64;
        zstd_comp_level		8;
	zstd_types		application/javascript
				application/json
				application/xhtml+xml
				application/xml
				font/opentype
				font/ttf
				image/svg+xml
				image/x-icon
				text/css
				text/plain;

	location /folder {
		alias			/mnt/web/folder;
		autoindex		on;
		autoindex_format	xml;

		xslt_string_param	footer $host;
		xslt_string_param	path $uri;
		xslt_string_param	layout $arg_layout;
		xslt_string_param	sort $arg_sort;
		xslt_string_param	order $arg_order;

		xslt_stylesheet		/etc/nginx/file_index.xslt;
	}
```

This request returns the following on request:
```
> GET /folder/ HTTP/2
> Host: server.example
> User-Agent: curl/8.11.0
> Accept: */*
> Accept-encoding: zstd
>
< HTTP/2 200
< date: Sun, 22 Dec 2024 14:54:58 GMT
< content-type: text/html; charset=UTF-8
< content-length: 43743
....
```

Updating the logic where the filter determines if its going to compress the response, aligning to what [Google ngx_brotli](https://github.com/google/ngx_brotli) uses, resolves the above issue.

Additionally lifting out the request check function to a shared code file ensures the logic is identical for both static and dynamic filters.