### PR TITLE
Run zstd before brotli if both are enabled

### DIFF
--- a/filter/config
+++ b/filter/config
@@ -128,8 +128,9 @@ ngx_module_order="$ngx_module_name \
 if [ "$ngx_module_link" != DYNAMIC ]; then
     # ngx_module_order doesn't work with static modules,
     # so we must re-order filters here.
-
-    if [ "$HTTP_GZIP" = YES ]; then
+    if echo $HTTP_FILTER_MODULES | grep ngx_http_brotli_filter_module >/dev/null; then
+        next=ngx_http_brotli_filter_module
+    elif [ "$HTTP_GZIP" = YES ]; then
         next=ngx_http_gzip_filter_module
     elif echo $HTTP_FILTER_MODULES | grep pagespeed_etag_filter >/dev/null; then
         next=ngx_pagespeed_etag_filter

--- a/static/config
+++ b/static/config
@@ -107,5 +107,7 @@ ngx_module_type=HTTP
 ngx_module_name=ngx_http_zstd_static_module
 ngx_module_incs="$ngx_zstd_opt_I"
 ngx_module_srcs=$HTTP_ZSTD_SRCS
+ngx_module_order="ngx_http_brotli_static_module \
+                  $ngx_module_name"
 
 . auto/module


### PR DESCRIPTION
Since Safari doesn't support zstd yet, I have to keep brotli enabled, however, this module is run after brotli, so if both are supported, brotli is used.  This is a problem since all browsers that support zstd also support brotli, so zstd is never actually used.

This PR reorders the module/filter before brotli so it takes priority (since it's faster and the compression is better). 

I took this patch from #40 by @mklooss (thanks!)