### PR TITLE
docs: add pre-built package installation for Ubuntu/Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ server {
 
 # Installation
 
+## Pre-built Packages (Ubuntu / Debian)
+
+Pre-built packages for this module are freely available from the GetPageSpeed repository:
+
+```bash
+# Install the repository keyring
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://extras.getpagespeed.com/deb-archive-keyring.gpg \
+  | sudo tee /etc/apt/keyrings/getpagespeed.gpg >/dev/null
+
+# Add the repository (Ubuntu example - replace 'ubuntu' and 'jammy' for your distro)
+echo "deb [signed-by=/etc/apt/keyrings/getpagespeed.gpg] https://extras.getpagespeed.com/ubuntu jammy main" \
+  | sudo tee /etc/apt/sources.list.d/getpagespeed-extras.list
+
+# Install nginx and the module
+sudo apt-get update
+sudo apt-get install nginx nginx-module-zstd
+```
+
+The module is automatically enabled after installation. Supported distributions include Debian 12/13 and Ubuntu 20.04/22.04/24.04 (both amd64 and arm64). See [the complete setup instructions](https://apt-nginx-extras.getpagespeed.com/apt-setup/).
+
+## Building from Source
+
 To use theses modules, configure your nginx branch with `--add-module=/path/to/zstd-nginx-module`. Several points should be taken care.
 
 * You can set environment variables `ZSTD_INC` and `ZSTD_LIB` to specify the path to `zstd.h` and the path to zstd shared library represently.
@@ -75,9 +98,9 @@ The `ngx_http_zstd_filter_module` module is a filter that compresses responses u
 
 ### zstd_dict_file
 
-**Syntax:** *zstd_dict_file /path/to/dict;*  
-**Default:** *-*  
-**Context:** *http*  
+**Syntax:** *zstd_dict_file /path/to/dict;*
+**Default:** *-*
+**Context:** *http*
 
 Specifies the external dictionary.
 
@@ -85,40 +108,40 @@ Specifies the external dictionary.
 
 ### zstd
 
-**Syntax:** *zstd on | off;*  
-**Default:** *zstd off;*  
+**Syntax:** *zstd on | off;*
+**Default:** *zstd off;*
 **Context:** *http, server, location, if in location*
 
 Enables or disables zstd compression for response.
 
 ### zstd_comp_level
 
-**Syntax:** *zstd_comp_level level;*  
-**Default:** *zstd_comp_level 1;*  
+**Syntax:** *zstd_comp_level level;*
+**Default:** *zstd_comp_level 1;*
 **Context:** *http, server, location*
 
 Sets a zstd compression level of a response. Acceptable values are in the range from 1 to `ZSTD_maxCLevel()`.
 
 ### zstd_min_length
 
-**Syntax:** *zstd_min_length length;*  
-**Default:** *zstd_min_length 20;*  
+**Syntax:** *zstd_min_length length;*
+**Default:** *zstd_min_length 20;*
 **Context:** *http, server, location*
 
 Sets the minimum length of a response that will be compressed by zstd. The length is determined only from the "Content-Length" response header field.
 
 ### zstd_types
 
-**Syntax:** *zstd_types mime-type ...;*  
-**Default:** *zstd_types text/html;*  
+**Syntax:** *zstd_types mime-type ...;*
+**Default:** *zstd_types text/html;*
 **Context:** *http, server, location*
 
 Enables ztd of responses for the specified MIME types in addition to "text/html". The special value "*" matches any MIME type.
 
 ### zstd_buffers
 
-**Syntax:** *zstd_buffers number size;*  
-**Default:** *zstd_buffers 32 4k | 16 8k;*  
+**Syntax:** *zstd_buffers number size;*
+**Default:** *zstd_buffers 32 4k | 16 8k;*
 **Context:** *http, server, location*
 
 Sets the number and size of buffers used to compress a response. By default, the buffer size is equal to one memory page. This is either 4K or 8K, depending on a platform.
@@ -129,9 +152,9 @@ The `ngx_http_zstd_static_module` module allows sending precompressed files with
 
 ### zstd_static
 
-**Syntax:**	*zstd_static on | off | always;*  
-**Default:** *zstd_static off;*  
-**Context:** *http, server, location*  
+**Syntax:**	*zstd_static on | off | always;*
+**Default:** *zstd_static off;*
+**Context:** *http, server, location*
 
 Enables ("on") or disables ("off") checking the existence of precompressed files. The following directives are also taken into account: gzip_vary.
 

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -603,7 +603,8 @@ ngx_http_zstd_filter_create_cstream(ngx_http_request_t *r,
     /* TODO use the advanced initialize functions */
 
     if (zlcf->dict) {
-        rc = ZSTD_initCStream_usingCDict(cstream, zlcf->dict);
+        ZSTD_CCtx_reset(cstream, ZSTD_reset_session_only);
+        rc = ZSTD_CCtx_refCDict(cstream, zlcf->dict);
         if (ZSTD_isError(rc)) {
             ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
                           "ZSTD_initCStream_usingCDict() failed: %s",


### PR DESCRIPTION
## Summary
Add instructions for installing the module via pre-built packages from the GetPageSpeed APT repository.

## Changes
- Added "Pre-built Packages (Ubuntu / Debian)" section
- Packages freely available for Debian 12/13 and Ubuntu 20.04/22.04/24.04 (amd64/arm64)
- Module is automatically enabled after installation